### PR TITLE
fix #22

### DIFF
--- a/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/TimeUtil.java
+++ b/sentinel-core/src/main/java/com/alibaba/csp/sentinel/util/TimeUtil.java
@@ -23,30 +23,9 @@ import java.util.concurrent.TimeUnit;
  * @author qinan.qn
  */
 public final class TimeUtil {
-
-    private static volatile long currentTimeMillis;
-
-    static {
-        currentTimeMillis = System.currentTimeMillis();
-        Thread daemon = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                while (true) {
-                    currentTimeMillis = System.currentTimeMillis();
-                    try {
-                        TimeUnit.MILLISECONDS.sleep(1);
-                    } catch (Throwable e) {
-
-                    }
-                }
-            }
-        });
-        daemon.setDaemon(true);
-        daemon.setName("sentinel-time-tick-thread");
-        daemon.start();
     }
 
     public static long currentTimeMillis() {
-        return currentTimeMillis;
+        return System.currentTimeMillis();
     }
 }


### PR DESCRIPTION
1. 移除TimeUtil类中的系统时间缓存和更新逻辑。
2. 简化TimeUtil类，移除过时的静态变量和线程。
3. 更新currentTimeMillis方法，使其直接返回系统当前时间。